### PR TITLE
126 endpoint for editing an existing comment

### DIFF
--- a/backend/src/main/java/pl/edu/pw/pap/comment/Comment.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/Comment.java
@@ -21,6 +21,7 @@ public class Comment {
     private Long id;
 
     private String text;
+    private Boolean edited;
     @CreationTimestamp
     private Timestamp created;
     @JsonIgnore
@@ -33,6 +34,7 @@ public class Comment {
 
     public Comment(String text, Review review, User user) {
         this.text = text;
+        this.edited = false;
         review.addComment(this);
         user.addComment(this);
     }
@@ -55,6 +57,7 @@ public class Comment {
         return "Comment{" +
                 "id=" + id +
                 ", text='" + text + '\'' +
+                ", text='" + edited + '\'' +
                 ", created=" + created.toString() +
                 ", review=" + review.getId() +
                 ", user=" + user.getId() +

--- a/backend/src/main/java/pl/edu/pw/pap/comment/Comment.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/Comment.java
@@ -43,7 +43,7 @@ public class Comment {
     }
 
     @PreRemove
-    public void preRemove(){
+    public void preRemove() {
         if (this.user != null) {
             this.user.removeComment(this);
         }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/Comment.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/Comment.java
@@ -57,7 +57,7 @@ public class Comment {
         return "Comment{" +
                 "id=" + id +
                 ", text='" + text + '\'' +
-                ", text='" + edited + '\'' +
+                ", edited='" + edited + '\'' +
                 ", created=" + created.toString() +
                 ", review=" + review.getId() +
                 ", user=" + user.getId() +

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
@@ -67,6 +67,11 @@ public class CommentController {
         return commentService.addNewComment(courseId, reviewerUsername, request, principal);
     }
 
+    @PutMapping("/api/comments/{commentId}")
+    public CommentDTO updateComment(@PathVariable Long commentId, @RequestBody UpdateCommentRequest request, @AuthenticationPrincipal UserPrincipal principal ) {
+        return commentService.updateComment(commentId, request, principal);
+    }
+
 
     @DeleteMapping("/api/comments/{commentId}")
     public ResponseEntity<CommentDTO> deleteComment(@PathVariable Long commentId, @AuthenticationPrincipal UserPrincipal principal) {

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
@@ -64,12 +64,12 @@ public class CommentController {
             @RequestBody AddCommentRequest request,
             @AuthenticationPrincipal UserPrincipal principal
     ) {
-        return commentService.addNewComment(courseId, reviewerUsername, request, principal);
+        return addLinks(commentService.addNewComment(courseId, reviewerUsername, request, principal));
     }
 
     @PutMapping("/api/comments/{commentId}")
     public CommentDTO updateComment(@PathVariable Long commentId, @RequestBody UpdateCommentRequest request, @AuthenticationPrincipal UserPrincipal principal ) {
-        return commentService.updateComment(commentId, request, principal);
+        return addLinks(commentService.updateComment(commentId, request, principal));
     }
 
 

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
@@ -98,7 +98,7 @@ public class CommentController {
     private CommentDTO addLinks(CommentDTO comment) {
         return comment.add(
                 linkTo(methodOn(CommentController.class).getCommentById(comment.getId())).withSelfRel(),
-                linkTo(methodOn(ReviewController.class).getReview(comment.getCourseId(), comment.getAuthorUsername())).withRel("review"),
+                linkTo(methodOn(ReviewController.class).getReview(comment.getCourseId(), comment.getReviewAuthorUsername())).withRel("review"),
                 linkTo(methodOn(UserController.class).getUser(comment.getAuthorUsername())).withRel("user")
         );
     }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentController.java
@@ -68,7 +68,7 @@ public class CommentController {
     }
 
     @PutMapping("/api/comments/{commentId}")
-    public CommentDTO updateComment(@PathVariable Long commentId, @RequestBody UpdateCommentRequest request, @AuthenticationPrincipal UserPrincipal principal ) {
+    public CommentDTO updateComment(@PathVariable Long commentId, @RequestBody UpdateCommentRequest request, @AuthenticationPrincipal UserPrincipal principal) {
         return addLinks(commentService.updateComment(commentId, request, principal));
     }
 

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentDTO.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentDTO.java
@@ -18,5 +18,6 @@ public class CommentDTO extends RepresentationModel<CommentDTO> {
     private Timestamp created;
     @JsonIgnore
     private Long courseId;
+    private Boolean edited;
 
 }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentDTO.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentDTO.java
@@ -18,6 +18,7 @@ public class CommentDTO extends RepresentationModel<CommentDTO> {
     private Timestamp created;
     @JsonIgnore
     private Long courseId;
+    private String reviewAuthorUsername;
     private Boolean edited;
 
 }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentRepository.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByReview_Id(ReviewKey reviewKey);
     List<Comment> findCommentsByUser_Username(String username);
+
 }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
@@ -108,7 +108,7 @@ public class CommentService {
     }
 
     public CommentDTO updateComment(Long commentId, UpdateCommentRequest request, UserPrincipal principal) {
-        // check if user has proper privalages
+        // check if user has proper privileges
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentNotFoundException("No comment with given ID: " + commentId + " found for edit"));
 

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
@@ -115,7 +115,7 @@ public class CommentService {
         // the throw shouldn't ever happen but we need the role in UserPrincipal to avoid this check
         User editingUser = userRepository.findByUsername(principal.getUsername())
                 .orElseThrow(() -> new UserNotFoundException("User asking for update doesn't exist"));
-        if (!comment.getUser().getId().equals(editingUser.getId()) && (!(editingUser.getRole().equals("ROLE_ADMIN")))) {
+        if (!comment.getUser().getId().equals(editingUser.getId())) {
             throw(new ForbiddenException(("You are not permitted to edit that comment")));
         }
         comment.setText(request.text());

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
@@ -62,7 +62,7 @@ public class CommentService {
         var comment = maybeComment.get();
         var user = maybeUser.get();
         if (!comment.getUser().getId().equals(user.getId()) && (!(user.getRole().equals("ROLE_ADMIN")))) {
-            throw(new ForbiddenException(("You are not permitted to delete that comment")));
+            throw (new ForbiddenException(("You are not permitted to delete that comment")));
         }
 
         commentRepository.delete(comment);
@@ -116,7 +116,7 @@ public class CommentService {
         User editingUser = userRepository.findByUsername(principal.getUsername())
                 .orElseThrow(() -> new UserNotFoundException("User asking for update doesn't exist"));
         if (!comment.getUser().getId().equals(editingUser.getId())) {
-            throw(new ForbiddenException(("You are not permitted to edit that comment")));
+            throw (new ForbiddenException(("You are not permitted to edit that comment")));
         }
         comment.setText(request.text());
         comment.setEdited(true);

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
@@ -121,7 +121,6 @@ public class CommentService {
         }
         comment.setText(request.text());
         comment.setEdited(true);
-        commentRepository.save(comment);
-        return convertToDto(comment);
+        return convertToDto(commentRepository.save(comment));
     }
 }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
@@ -32,6 +32,7 @@ public class CommentService {
                 .text(comment.getText())
                 .created(comment.getCreated())
                 .courseId(comment.getReview().getCourse().getId())
+                .edited(comment.getEdited())
                 .build();
     }
 
@@ -118,6 +119,7 @@ public class CommentService {
             throw(new ForbiddenException(("You are not permitted to delete that comment")));
         }
         comment.setText(request.text());
+        comment.setEdited(true);
         commentRepository.save(comment);
         return convertToDto(comment);
     }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
@@ -32,6 +32,7 @@ public class CommentService {
                 .text(comment.getText())
                 .created(comment.getCreated())
                 .courseId(comment.getReview().getCourse().getId())
+                .reviewAuthorUsername(comment.getReview().getUser().getUsername())
                 .edited(comment.getEdited())
                 .build();
     }

--- a/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/CommentService.java
@@ -110,13 +110,13 @@ public class CommentService {
     public CommentDTO updateComment(Long commentId, UpdateCommentRequest request, UserPrincipal principal) {
         // check if user has proper privalages
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentNotFoundException("No comment with given ID: " + commentId.toString() + " found for edit"));
+                .orElseThrow(() -> new CommentNotFoundException("No comment with given ID: " + commentId + " found for edit"));
 
         // the throw shouldn't ever happen but we need the role in UserPrincipal to avoid this check
         User editingUser = userRepository.findByUsername(principal.getUsername())
                 .orElseThrow(() -> new UserNotFoundException("User asking for update doesn't exist"));
         if (!comment.getUser().getId().equals(editingUser.getId()) && (!(editingUser.getRole().equals("ROLE_ADMIN")))) {
-            throw(new ForbiddenException(("You are not permitted to delete that comment")));
+            throw(new ForbiddenException(("You are not permitted to edit that comment")));
         }
         comment.setText(request.text());
         comment.setEdited(true);

--- a/backend/src/main/java/pl/edu/pw/pap/comment/UpdateCommentRequest.java
+++ b/backend/src/main/java/pl/edu/pw/pap/comment/UpdateCommentRequest.java
@@ -1,0 +1,4 @@
+package pl.edu.pw.pap.comment;
+
+public record UpdateCommentRequest(String text) {
+}

--- a/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
@@ -323,7 +323,6 @@ public class CommentIntegrationTest {
     }
 
 
-
     @Test
     public void updateCommentByAdmin() {
         adminLogin();
@@ -342,7 +341,8 @@ public class CommentIntegrationTest {
         // make sure nothing was changed
         assertEquals("rel", commentJson.read("text"));
         assertEquals("user_3", commentJson.read("authorUsername"));
-        assertEquals(false, commentJson.read("edited"));}
+        assertEquals(false, commentJson.read("edited"));
+    }
 
     @Test
     public void updateCommentNotExist() {
@@ -364,9 +364,6 @@ public class CommentIntegrationTest {
                 HttpMethod.PUT, new HttpEntity<>(request, headers), String.class);
         assertEquals(HttpStatusCode.valueOf(404), response.getStatusCode());
     }
-
-
-
 
 
 }

--- a/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
@@ -327,24 +327,22 @@ public class CommentIntegrationTest {
     @Test
     public void updateCommentByAdmin() {
         adminLogin();
-        String endpoint = "/api/comments/1"; // by user_3
-        var request = new UpdateCommentRequest("nowy tekscik");
 
+        String endpoint = "/api/comments/1"; // by user 3 user_3
+        var request = new UpdateCommentRequest("nowy tekscik");
         var response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.PUT, new HttpEntity<>(request, headers), String.class);
-        assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
-
+        assertEquals(HttpStatusCode.valueOf(403), response.getStatusCode());
 
         response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.GET, new HttpEntity<>(headers), String.class);
         assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
         var commentJson = JsonPath.parse(response.getBody());
 
-        // make sure appropriate things were changed
-        assertEquals("nowy tekscik", commentJson.read("text"));
+        // make sure nothing was changed
+        assertEquals("rel", commentJson.read("text"));
         assertEquals("user_3", commentJson.read("authorUsername"));
-        assertEquals(true, commentJson.read("edited"));
-    }
+        assertEquals(false, commentJson.read("edited"));}
 
     @Test
     public void updateCommentNotExist() {

--- a/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
@@ -209,6 +209,13 @@ public class CommentIntegrationTest {
         var response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.POST, new HttpEntity<>(request, headers), String.class);
         assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        var commentJson = JsonPath.parse(response.getBody());
+
+        // check links
+        assertTrue(commentJson.read("$._links.self.href").toString().endsWith("/api/comments/6"));
+        assertTrue(commentJson.read("$._links.user.href").toString().endsWith("/api/users/rdeckard"));
+        assertTrue(commentJson.read("$._links.review.href").toString().endsWith("/api/courses/4/reviews/rbatty"));
+
 
         response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.GET, new HttpEntity<>(request, headers), String.class);
@@ -219,6 +226,7 @@ public class CommentIntegrationTest {
         assertEquals("rdeckard", com.get("authorUsername"));
         assertTrue(com.containsKey("id"));
         assertTrue(com.containsKey("created"));
+
     }
 
     @Test
@@ -228,6 +236,13 @@ public class CommentIntegrationTest {
         var response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.POST, new HttpEntity<>(request, headers), String.class);
         assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        var commentJson = JsonPath.parse(response.getBody());
+
+        // check links
+        assertTrue(commentJson.read("$._links.self.href").toString().endsWith("/api/comments/6"));
+        assertTrue(commentJson.read("$._links.user.href").toString().endsWith("/api/users/rdeckard"));
+        assertTrue(commentJson.read("$._links.review.href").toString().endsWith("/api/courses/3/reviews/rdeckard"));
+
 
         response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.GET, new HttpEntity<>(request, headers), String.class);
@@ -297,6 +312,12 @@ public class CommentIntegrationTest {
         assertEquals("nowy tekscik", returnedComment.read("text"));
         assertEquals("rdeckard", returnedComment.read("authorUsername"));
         assertEquals(true, returnedComment.read("edited"));
+
+        // check links
+        assertTrue(returnedComment.read("$._links.self.href").toString().endsWith("/api/comments/3"));
+        assertTrue(returnedComment.read("$._links.user.href").toString().endsWith("/api/users/rdeckard"));
+        assertTrue(returnedComment.read("$._links.review.href").toString().endsWith("/api/courses/1/reviews/rbatty"));
+
 
         response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.GET, new HttpEntity<>(request, headers), String.class);

--- a/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
@@ -97,7 +97,7 @@ public class CommentIntegrationTest {
         // check links
         assertTrue(json.read("$._links.self.href").toString().endsWith("/api/courses/1/reviews/rdeckard/comments"));
         assertTrue(json.read("$._embedded.comments[0]._links.self.href").toString().endsWith("/api/comments/1"));
-        assertTrue(json.read("$._embedded.comments[0]._links.review.href").toString().endsWith("/api/courses/1/reviews/user_3"));
+        assertTrue(json.read("$._embedded.comments[0]._links.review.href").toString().endsWith("/api/courses/1/reviews/rdeckard"));
         assertTrue(json.read("$._embedded.comments[0]._links.user.href").toString().endsWith("/api/users/user_3"));
     }
 

--- a/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
+++ b/backend/src/test/java/pl/edu/pw/pap/comment/CommentIntegrationTest.java
@@ -293,6 +293,10 @@ public class CommentIntegrationTest {
         var response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.PUT, new HttpEntity<>(request, headers), String.class);
         assertEquals(HttpStatusCode.valueOf(200), response.getStatusCode());
+        var returnedComment = JsonPath.parse(response.getBody());
+        assertEquals("nowy tekscik", returnedComment.read("text"));
+        assertEquals("rdeckard", returnedComment.read("authorUsername"));
+        assertEquals(true, returnedComment.read("edited"));
 
         response = restTemplate.exchange(buildUrl(endpoint, port),
                 HttpMethod.GET, new HttpEntity<>(request, headers), String.class);
@@ -301,6 +305,14 @@ public class CommentIntegrationTest {
 
         assertEquals("nowy tekscik", commentJson.read("text"));
         assertEquals("rdeckard", commentJson.read("authorUsername"));
+
+
+        // check links
+        assertTrue(commentJson.read("$._links.self.href").toString().endsWith("/api/comments/3"));
+        assertTrue(commentJson.read("$._links.user.href").toString().endsWith("/api/users/rdeckard"));
+        assertTrue(commentJson.read("$._links.review.href").toString().endsWith("/api/courses/1/reviews/rbatty"));
+
+
     }
 
     @Test
@@ -320,6 +332,8 @@ public class CommentIntegrationTest {
         assertEquals("rel", commentJson.read("text"));
         assertEquals("user_3", commentJson.read("authorUsername"));
         assertEquals(false, commentJson.read("edited"));
+
+
     }
 
 
@@ -342,6 +356,8 @@ public class CommentIntegrationTest {
         assertEquals("rel", commentJson.read("text"));
         assertEquals("user_3", commentJson.read("authorUsername"));
         assertEquals(false, commentJson.read("edited"));
+
+
     }
 
     @Test


### PR DESCRIPTION
added an endpoint for editing a comment with the proper permission checks and checking if the comment even exists
closes #126 